### PR TITLE
Windows scroll direction; fixes; edge sproing limits

### DIFF
--- a/build.py
+++ b/build.py
@@ -28,7 +28,7 @@ subprocess.run([
     'build', 'src',
     '-target:js_wasm32',
     f"-out:build/{program_name}.wasm",
-    '-o:speed', '-debug'
+    '-o:speed'
 ])
 print("Compiled in {:.1f} seconds".format(time.time() - start_time))
 

--- a/src/config.odin
+++ b/src/config.odin
@@ -67,7 +67,12 @@ push_event :: proc(processes: ^[dynamic]Process, event: Event) {
 
 pid_sort_proc :: proc(a, b: Process) -> bool { return a.min_time < b.min_time }
 tid_sort_proc :: proc(a, b: Thread) -> bool  { return a.min_time < b.min_time }
-event_sort_proc :: proc(a, b: Event) -> bool { return a.timestamp < b.timestamp }
+event_sort_proc :: proc(a, b: Event) -> bool {
+	if a.timestamp == b.timestamp {
+		return a.duration > b.duration
+	}
+	return a.timestamp < b.timestamp
+}
 process_events :: proc(processes: ^[dynamic]Process) -> u16 {
 	total_max_depth : u16 = 0
 

--- a/src/main.odin
+++ b/src/main.odin
@@ -170,12 +170,12 @@ main :: proc() {
     arena_init(&temp_arena, temp_data)
     arena_init(&scratch_arena, scratch_data)
 
-	// This must be init last, because it grows infinitely. 
+	// This must be init last, because it grows infinitely.
 	// We don't want it accidentally growing into anything useful.
     growing_arena_init(&global_arena)
 
-	// I'm doing olympic-level memory juggling BS in the ingest system because 
-	// arenas are *special*, and memory is *precious*. Beware free_all()'ing 
+	// I'm doing olympic-level memory juggling BS in the ingest system because
+	// arenas are *special*, and memory is *precious*. Beware free_all()'ing
 	// the wrong one at the wrong time, here thar be dragons. Once you're in
 	// normal render/frame space, I free_all temp once per frame, and I shouldn't
 	// need to touch scratch
@@ -233,7 +233,7 @@ frame :: proc "contextless" (width, height: f64, dt: f64) -> bool {
 			cur_y := f64(i /  int(chunk_size))
 			draw_rect(rect(start_x + (cur_x * chunk_size), start_y + (cur_y * chunk_size), chunk_size - pad_size, chunk_size - pad_size), Vec3{0, 255, 0})
 		}
-		
+
 		return true
 	}
 
@@ -460,8 +460,8 @@ frame :: proc "contextless" (width, height: f64, dt: f64) -> bool {
 				}
 
 				rect_color := color_choices[ev.depth - 1]
-				if int(selected_event.pid) == p_idx && 
-				   int(selected_event.tid) == t_idx && 
+				if int(selected_event.pid) == p_idx &&
+				   int(selected_event.tid) == t_idx &&
 				   int(selected_event.eid) == e_idx {
 					rect_color.x += 30
 					rect_color.y += 30
@@ -512,7 +512,7 @@ frame :: proc "contextless" (width, height: f64, dt: f64) -> bool {
     draw_rect(rect(0, disp_rect.pos.y, graph_rect.pos.x, height), bg_color2) // left
     draw_rect(rect(graph_rect.pos.x + graph_rect.size.x, disp_rect.pos.y, width, height), bg_color2) // right
 
-	
+
 	// Draw timestamps on subdivision lines
 	ONE_SECOND :: 1000 * 1000
 	ONE_MILLI :: 1000
@@ -581,9 +581,9 @@ frame :: proc "contextless" (width, height: f64, dt: f64) -> bool {
 	case .Auto:
 		color_text = "\uf042"
 	case .Dark:
-		color_text = "\uf10c" 
+		color_text = "\uf10c"
 	case .Light:
-		color_text = "\uf111" 
+		color_text = "\uf111"
 	}
 
 	if button(rect(width - edge_pad - button_width, (toolbar_height / 2) - (button_height / 2), button_width, button_height), color_text, icon_font) {

--- a/src/main.odin
+++ b/src/main.odin
@@ -167,26 +167,26 @@ main :: proc() {
 	temp_data, _    := js.page_alloc(ONE_MB_PAGES * 15)
 	scratch_data, _ := js.page_alloc(ONE_MB_PAGES * 10)
 
-    arena_init(&temp_arena, temp_data)
-    arena_init(&scratch_arena, scratch_data)
+	arena_init(&temp_arena, temp_data)
+	arena_init(&scratch_arena, scratch_data)
 
 	// This must be init last, because it grows infinitely.
 	// We don't want it accidentally growing into anything useful.
-    growing_arena_init(&global_arena)
+	growing_arena_init(&global_arena)
 
 	// I'm doing olympic-level memory juggling BS in the ingest system because
 	// arenas are *special*, and memory is *precious*. Beware free_all()'ing
 	// the wrong one at the wrong time, here thar be dragons. Once you're in
 	// normal render/frame space, I free_all temp once per frame, and I shouldn't
 	// need to touch scratch
-    temp_allocator = arena_allocator(&temp_arena)
-    scratch_allocator = arena_allocator(&scratch_arena)
-    global_allocator = growing_arena_allocator(&global_arena)
+	temp_allocator = arena_allocator(&temp_arena)
+	scratch_allocator = arena_allocator(&scratch_arena)
+	global_allocator = growing_arena_allocator(&global_arena)
 
 	wasmContext.allocator = global_allocator
 	wasmContext.temp_allocator = temp_allocator
 
-    context = wasmContext
+	context = wasmContext
 
 	manual_load(default_config)
 }
@@ -201,7 +201,7 @@ get_current_window :: proc(cam: Camera, display_width: f64) -> (i64, i64) {
 
 @export
 frame :: proc "contextless" (width, height: f64, dt: f64) -> bool {
-    context = wasmContext
+	context = wasmContext
 	defer frame_count += 1
 
 	// This is nasty code that allows me to do load-time things once the wasm context is init
@@ -246,7 +246,7 @@ frame :: proc "contextless" (width, height: f64, dt: f64) -> bool {
 		is_hovering = false
 	}
 
-    t += dt
+	t += dt
 
 	if (width / dpr) < 400 {
 		p_font_size = _p_font_size * dpr
@@ -306,10 +306,10 @@ frame :: proc "contextless" (width, height: f64, dt: f64) -> bool {
 		finished_loading = false
 	}
 
-    canvas_clear()
+	canvas_clear()
 
 	// Render background
-    draw_rect(rect(0, toolbar_height, width, height), bg_color2)
+	draw_rect(rect(0, toolbar_height, width, height), bg_color2)
 
 	graph_header_text_height := (top_line_gap * 2) + em
 	graph_header_line_gap := em
@@ -508,9 +508,9 @@ frame :: proc "contextless" (width, height: f64, dt: f64) -> bool {
 
 
 	// Chop sides of screen
-    draw_rect(rect(0, disp_rect.pos.y, width, graph_header_text_height), bg_color2) // top
-    draw_rect(rect(0, disp_rect.pos.y, graph_rect.pos.x, height), bg_color2) // left
-    draw_rect(rect(graph_rect.pos.x + graph_rect.size.x, disp_rect.pos.y, width, height), bg_color2) // right
+	draw_rect(rect(0, disp_rect.pos.y, width, graph_header_text_height), bg_color2) // top
+	draw_rect(rect(0, disp_rect.pos.y, graph_rect.pos.x, height), bg_color2) // left
+	draw_rect(rect(graph_rect.pos.x + graph_rect.size.x, disp_rect.pos.y, width, height), bg_color2) // right
 
 
 	// Draw timestamps on subdivision lines
@@ -537,7 +537,7 @@ frame :: proc "contextless" (width, height: f64, dt: f64) -> bool {
 
 	// Render info pane
 	draw_line(Vec2{0, info_pane_y}, Vec2{width, info_pane_y}, 1, line_color)
-    draw_rect(rect(0, info_pane_y, width, height), bg_color) // bottom
+	draw_rect(rect(0, info_pane_y, width, height), bg_color) // bottom
 
 	if selected_event.pid != -1 && selected_event.tid != -1 && selected_event.eid != -1 {
 		p_idx := int(selected_event.pid)
@@ -567,7 +567,7 @@ frame :: proc "contextless" (width, height: f64, dt: f64) -> bool {
 	}
 
 	// Render toolbar background
-    draw_rect(rect(0, 0, width, toolbar_height), toolbar_color)
+	draw_rect(rect(0, 0, width, toolbar_height), toolbar_color)
 
 	// draw toolbar
 	edge_pad := 1 * em
@@ -639,7 +639,7 @@ frame :: proc "contextless" (width, height: f64, dt: f64) -> bool {
 	seed_width := measure_text(seed_str, p_font_size, monospace_font)
 	draw_text(seed_str, Vec2{width - seed_width - x_subpad, prev_line(&y, em)}, p_font_size, monospace_font, text_color2)
 
-    return true
+	return true
 }
 
 button :: proc(in_rect: Rect, text: string, font: string) -> bool {

--- a/src/main.odin
+++ b/src/main.odin
@@ -340,7 +340,7 @@ frame :: proc "contextless" (width, height: f64, dt: f64) -> bool {
 
 	MAX_SCALE :: 100000
 	if pt_in_rect(mouse_pos, disp_rect) {
-		cam.target_scale *= _pow(1.003, scroll_val_y)
+		cam.target_scale *= _pow(1.0025, -scroll_val_y)
 		scroll_val_y = 0
 	}
 


### PR DESCRIPTION
1. Windows scroll direction (scroll up to zoom in)
    - Also tweaked the zoom exponential base slightly. I think this is purely preferential.
2. Remove -debug from odin build flags
3. Subsort events with equal start by duration, descending
    - Fixes overlap bug when multiple events start at 0
4. Horizontal limits to middle of display
5. Don't fight back on edge sproings per-frame, only as mouse moves
    - Exponentially harder to push past the edge